### PR TITLE
feat: 산책 매칭 기능 구현

### DIFF
--- a/src/main/java/com/pawpaw/pawpaw/domain/walk/controller/WalkRequestController.java
+++ b/src/main/java/com/pawpaw/pawpaw/domain/walk/controller/WalkRequestController.java
@@ -1,0 +1,46 @@
+package com.pawpaw.pawpaw.domain.walk.controller;
+
+import com.pawpaw.pawpaw.domain.walk.dto.WalkRequestDto;
+import com.pawpaw.pawpaw.domain.walk.dto.WalkRequestResponseDto;
+import com.pawpaw.pawpaw.domain.walk.service.WalkRequestService;
+import com.pawpaw.pawpaw.domain.user.entity.User;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/walk-requests")
+@RequiredArgsConstructor
+public class WalkRequestController {
+
+    private final WalkRequestService walkRequestService;
+
+    @PostMapping
+    public ResponseEntity<WalkRequestResponseDto> createWalkRequest(
+            @Valid @RequestBody WalkRequestDto dto,
+            @AuthenticationPrincipal User user) {
+        return ResponseEntity.ok(walkRequestService.createWalkRequest(dto, user));
+    }
+
+    @GetMapping
+    public ResponseEntity<List<WalkRequestResponseDto>> getAllWalkRequests() {
+        return ResponseEntity.ok(walkRequestService.getAllWalkRequests());
+    }
+
+    @GetMapping("/{walkRequestId}")
+    public ResponseEntity<WalkRequestResponseDto> getWalkRequest(@PathVariable Long walkRequestId) {
+        return ResponseEntity.ok(walkRequestService.getWalkRequest(walkRequestId));
+    }
+
+    @DeleteMapping("/{walkRequestId}")
+    public ResponseEntity<Void> deleteWalkRequest(
+            @PathVariable Long walkRequestId,
+            @AuthenticationPrincipal User user) {
+        walkRequestService.deleteWalkRequest(walkRequestId, user);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/pawpaw/pawpaw/domain/walk/dto/WalkApplicationRequestDto.java
+++ b/src/main/java/com/pawpaw/pawpaw/domain/walk/dto/WalkApplicationRequestDto.java
@@ -1,0 +1,8 @@
+package com.pawpaw.pawpaw.domain.walk.dto;
+
+import lombok.Getter;
+
+@Getter
+public class WalkApplicationRequestDto {
+    private String message;
+}

--- a/src/main/java/com/pawpaw/pawpaw/domain/walk/dto/WalkApplicationResponseDto.java
+++ b/src/main/java/com/pawpaw/pawpaw/domain/walk/dto/WalkApplicationResponseDto.java
@@ -1,0 +1,23 @@
+package com.pawpaw.pawpaw.domain.walk.dto;
+
+import com.pawpaw.pawpaw.domain.walk.entity.WalkApplication;
+import com.pawpaw.pawpaw.domain.walk.entity.WalkApplicationStatus;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class WalkApplicationResponseDto {
+
+    private Long id;
+    private String nickname;
+    private WalkApplicationStatus status;
+    private LocalDateTime appliedAt;
+
+    public WalkApplicationResponseDto(WalkApplication walkApplication) {
+        this.id = walkApplication.getId();
+        this.nickname = walkApplication.getUser().getNickname();
+        this.status = walkApplication.getStatus();
+        this.appliedAt = walkApplication.getAppliedAt();
+    }
+}

--- a/src/main/java/com/pawpaw/pawpaw/domain/walk/dto/WalkRequestDto.java
+++ b/src/main/java/com/pawpaw/pawpaw/domain/walk/dto/WalkRequestDto.java
@@ -1,0 +1,33 @@
+package com.pawpaw.pawpaw.domain.walk.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Getter
+public class WalkRequestDto {
+
+    @NotBlank
+    private String title;
+
+    @NotBlank
+    private String content;
+
+    @NotNull
+    private Long petId;
+
+    @NotNull
+    private LocalDate walkDate;
+
+    @NotNull
+    private LocalTime startTime;
+
+    @NotNull
+    private LocalTime endTime;
+
+    private String reward;
+    private String location;
+}

--- a/src/main/java/com/pawpaw/pawpaw/domain/walk/dto/WalkRequestResponseDto.java
+++ b/src/main/java/com/pawpaw/pawpaw/domain/walk/dto/WalkRequestResponseDto.java
@@ -1,0 +1,41 @@
+package com.pawpaw.pawpaw.domain.walk.dto;
+
+import com.pawpaw.pawpaw.domain.walk.entity.WalkRequest;
+import com.pawpaw.pawpaw.domain.walk.entity.WalkRequestStatus;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.LocalDateTime;
+
+@Getter
+public class WalkRequestResponseDto {
+
+    private Long id;
+    private String title;
+    private String content;
+    private String nickname;
+    private String petName;
+    private LocalDate walkDate;
+    private LocalTime startTime;
+    private LocalTime endTime;
+    private String reward;
+    private String location;
+    private WalkRequestStatus status;
+    private LocalDateTime createdAt;
+
+    public WalkRequestResponseDto(WalkRequest walkRequest) {
+        this.id = walkRequest.getId();
+        this.title = walkRequest.getTitle();
+        this.content = walkRequest.getContent();
+        this.nickname = walkRequest.getUser().getNickname();
+        this.petName = walkRequest.getPet().getName();
+        this.walkDate = walkRequest.getWalkDate();
+        this.startTime = walkRequest.getStartTime();
+        this.endTime = walkRequest.getEndTime();
+        this.reward = walkRequest.getReward();
+        this.location = walkRequest.getLocation();
+        this.status = walkRequest.getStatus();
+        this.createdAt = walkRequest.getCreatedAt();
+    }
+}

--- a/src/main/java/com/pawpaw/pawpaw/domain/walk/entity/WalkApplication.java
+++ b/src/main/java/com/pawpaw/pawpaw/domain/walk/entity/WalkApplication.java
@@ -37,4 +37,8 @@ public class WalkApplication {
     @CreatedDate
     @Column(updatable = false)
     private LocalDateTime appliedAt;
+
+    public void updateStatus(WalkApplicationStatus status) {
+        this.status = status;
+    }
 }

--- a/src/main/java/com/pawpaw/pawpaw/domain/walk/entity/WalkRequest.java
+++ b/src/main/java/com/pawpaw/pawpaw/domain/walk/entity/WalkRequest.java
@@ -50,4 +50,8 @@ public class WalkRequest extends BaseEntity {
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)
     private WalkRequestStatus status;
+
+    public void updateStatus(WalkRequestStatus status) {
+        this.status = status;
+    }
 }

--- a/src/main/java/com/pawpaw/pawpaw/domain/walk/repository/WalkApplicationRepository.java
+++ b/src/main/java/com/pawpaw/pawpaw/domain/walk/repository/WalkApplicationRepository.java
@@ -1,0 +1,13 @@
+package com.pawpaw.pawpaw.domain.walk.repository;
+
+import com.pawpaw.pawpaw.domain.walk.entity.WalkApplication;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface WalkApplicationRepository extends JpaRepository<WalkApplication, Long> {
+    List<WalkApplication> findByWalkRequestId(Long walkRequestId);
+    Optional<WalkApplication> findByWalkRequestIdAndUserId(Long walkRequestId, Long userId);
+    boolean existsByWalkRequestIdAndUserId(Long walkRequestId, Long userId);
+}

--- a/src/main/java/com/pawpaw/pawpaw/domain/walk/repository/WalkRequestRepository.java
+++ b/src/main/java/com/pawpaw/pawpaw/domain/walk/repository/WalkRequestRepository.java
@@ -1,0 +1,13 @@
+package com.pawpaw.pawpaw.domain.walk.repository;
+
+import com.pawpaw.pawpaw.domain.walk.entity.WalkRequest;
+import com.pawpaw.pawpaw.domain.walk.entity.WalkRequestStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface WalkRequestRepository extends JpaRepository<WalkRequest, Long> {
+    List<WalkRequest> findAllByOrderByCreatedAtDesc();
+    List<WalkRequest> findByStatusOrderByCreatedAtDesc(WalkRequestStatus status);
+    List<WalkRequest> findByUserIdOrderByCreatedAtDesc(Long userId);
+}

--- a/src/main/java/com/pawpaw/pawpaw/domain/walk/service/WalkApplicationService.java
+++ b/src/main/java/com/pawpaw/pawpaw/domain/walk/service/WalkApplicationService.java
@@ -1,0 +1,76 @@
+package com.pawpaw.pawpaw.domain.walk.service;
+
+import com.pawpaw.pawpaw.domain.walk.dto.WalkApplicationResponseDto;
+import com.pawpaw.pawpaw.domain.walk.entity.WalkApplication;
+import com.pawpaw.pawpaw.domain.walk.entity.WalkApplicationStatus;
+import com.pawpaw.pawpaw.domain.walk.entity.WalkRequest;
+import com.pawpaw.pawpaw.domain.walk.entity.WalkRequestStatus;
+import com.pawpaw.pawpaw.domain.walk.repository.WalkApplicationRepository;
+import com.pawpaw.pawpaw.domain.walk.repository.WalkRequestRepository;
+import com.pawpaw.pawpaw.domain.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class WalkApplicationService {
+
+    private final WalkApplicationRepository walkApplicationRepository;
+    private final WalkRequestRepository walkRequestRepository;
+
+    @Transactional
+    public WalkApplicationResponseDto apply(Long walkRequestId, User user) {
+        WalkRequest walkRequest = walkRequestRepository.findById(walkRequestId)
+                .orElseThrow(() -> new IllegalArgumentException("산책 요청을 찾을 수 없습니다."));
+
+        if (walkRequest.getUser().getId().equals(user.getId())) {
+            throw new IllegalArgumentException("본인의 산책 요청에는 신청할 수 없습니다.");
+        }
+
+        if (walkApplicationRepository.existsByWalkRequestIdAndUserId(walkRequestId, user.getId())) {
+            throw new IllegalArgumentException("이미 신청한 산책 요청입니다.");
+        }
+
+        if (!walkRequest.getStatus().equals(WalkRequestStatus.OPEN)) {
+            throw new IllegalArgumentException("모집이 마감된 산책 요청입니다.");
+        }
+
+        WalkApplication walkApplication = WalkApplication.builder()
+                .walkRequest(walkRequest)
+                .user(user)
+                .status(WalkApplicationStatus.PENDING)
+                .build();
+
+        return new WalkApplicationResponseDto(walkApplicationRepository.save(walkApplication));
+    }
+
+    @Transactional(readOnly = true)
+    public List<WalkApplicationResponseDto> getApplications(Long walkRequestId) {
+        return walkApplicationRepository.findByWalkRequestId(walkRequestId)
+                .stream()
+                .map(WalkApplicationResponseDto::new)
+                .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public WalkApplicationResponseDto acceptApplication(Long walkRequestId, Long applicationId, User user) {
+        WalkRequest walkRequest = walkRequestRepository.findById(walkRequestId)
+                .orElseThrow(() -> new IllegalArgumentException("산책 요청을 찾을 수 없습니다."));
+
+        if (!walkRequest.getUser().getId().equals(user.getId())) {
+            throw new IllegalArgumentException("수락 권한이 없습니다.");
+        }
+
+        WalkApplication walkApplication = walkApplicationRepository.findById(applicationId)
+                .orElseThrow(() -> new IllegalArgumentException("신청을 찾을 수 없습니다."));
+
+        walkApplication.updateStatus(WalkApplicationStatus.ACCEPTED);
+        walkRequest.updateStatus(WalkRequestStatus.MATCHED);
+
+        return new WalkApplicationResponseDto(walkApplication);
+    }
+}

--- a/src/main/java/com/pawpaw/pawpaw/domain/walk/service/WalkRequestService.java
+++ b/src/main/java/com/pawpaw/pawpaw/domain/walk/service/WalkRequestService.java
@@ -1,0 +1,72 @@
+package com.pawpaw.pawpaw.domain.walk.service;
+
+import com.pawpaw.pawpaw.domain.pet.entity.Pet;
+import com.pawpaw.pawpaw.domain.pet.repository.PetRepository;
+import com.pawpaw.pawpaw.domain.walk.dto.WalkRequestDto;
+import com.pawpaw.pawpaw.domain.walk.dto.WalkRequestResponseDto;
+import com.pawpaw.pawpaw.domain.walk.entity.WalkRequest;
+import com.pawpaw.pawpaw.domain.walk.entity.WalkRequestStatus;
+import com.pawpaw.pawpaw.domain.user.entity.User;
+import com.pawpaw.pawpaw.domain.walk.repository.WalkRequestRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class WalkRequestService {
+
+    private final WalkRequestRepository walkRequestRepository;
+    private final PetRepository petRepository;
+
+    @Transactional
+    public WalkRequestResponseDto createWalkRequest(WalkRequestDto dto, User user) {
+        Pet pet = petRepository.findById(dto.getPetId())
+                .orElseThrow(() -> new IllegalArgumentException("펫을 찾을 수 없습니다."));
+
+        WalkRequest walkRequest = WalkRequest.builder()
+                .user(user)
+                .pet(pet)
+                .title(dto.getTitle())
+                .content(dto.getContent())
+                .walkDate(dto.getWalkDate())
+                .startTime(dto.getStartTime())
+                .endTime(dto.getEndTime())
+                .reward(dto.getReward())
+                .location(dto.getLocation())
+                .status(WalkRequestStatus.OPEN)
+                .build();
+
+        return new WalkRequestResponseDto(walkRequestRepository.save(walkRequest));
+    }
+
+    @Transactional(readOnly = true)
+    public List<WalkRequestResponseDto> getAllWalkRequests() {
+        return walkRequestRepository.findAllByOrderByCreatedAtDesc()
+                .stream()
+                .map(WalkRequestResponseDto::new)
+                .collect(Collectors.toList());
+    }
+
+    @Transactional(readOnly = true)
+    public WalkRequestResponseDto getWalkRequest(Long walkRequestId) {
+        WalkRequest walkRequest = walkRequestRepository.findById(walkRequestId)
+                .orElseThrow(() -> new IllegalArgumentException("산책 요청을 찾을 수 없습니다."));
+        return new WalkRequestResponseDto(walkRequest);
+    }
+
+    @Transactional
+    public void deleteWalkRequest(Long walkRequestId, User user) {
+        WalkRequest walkRequest = walkRequestRepository.findById(walkRequestId)
+                .orElseThrow(() -> new IllegalArgumentException("산책 요청을 찾을 수 없습니다."));
+
+        if (!walkRequest.getUser().getId().equals(user.getId())) {
+            throw new IllegalArgumentException("삭제 권한이 없습니다.");
+        }
+
+        walkRequestRepository.delete(walkRequest);
+    }
+}


### PR DESCRIPTION
## 작업 내용
- 산책 요청 CRUD 구현
- 산책 신청/수락 기능 구현
- 중복 신청 방지 처리
- 본인 요청 신청 방지 처리

## API 목록
- POST /api/walk-requests - 산책 요청 작성
- GET /api/walk-requests - 산책 요청 목록 조회
- GET /api/walk-requests/{walkRequestId} - 산책 요청 단건 조회
- DELETE /api/walk-requests/{walkRequestId} - 산책 요청 삭제
- POST /api/walk-requests/{walkRequestId}/applications - 산책 신청
- GET /api/walk-requests/{walkRequestId}/applications - 신청 목록 조회
- PATCH /api/walk-requests/{walkRequestId}/applications/{applicationId}/accept - 신청 수락