### PR TITLE
[FIX] 산책 요청 등록 시 펫 소유권 미검증 수정 (#16)

### DIFF
--- a/src/main/java/com/pawpaw/pawpaw/domain/walk/service/WalkRequestService.java
+++ b/src/main/java/com/pawpaw/pawpaw/domain/walk/service/WalkRequestService.java
@@ -30,6 +30,10 @@ public class WalkRequestService {
         Pet pet = petRepository.findById(dto.getPetId())
                 .orElseThrow(() -> new IllegalArgumentException("펫을 찾을 수 없습니다."));
 
+        if (!pet.getUser().getId().equals(user.getId())) {
+            throw new IllegalArgumentException("본인의 펫으로만 산책 요청을 등록할 수 있습니다.");
+        }
+
         LocalDate today = LocalDate.now();
         LocalTime now = LocalTime.now();
 


### PR DESCRIPTION
## 📌 개요
산책 요청 등록 시 `petId`로 펫을 조회하기만 하고 요청자 본인의 펫인지 확인하지 않는 문제를 수정합니다. 타인의 펫으로 산책 요청을 등록할 수 없도록 소유권 검증 로직을 추가합니다.

## 🔍 변경 사유
- `WalkRequestService.createWalkRequest()`에서 펫 소유자 검증 누락
- 타인의 `petId`를 사용한 산책 요청 등록 가능 → 데이터 무결성 위반

## 🛠 작업 내용
- [x] 펫 조회 후 `pet.getUser().getId().equals(user.getId())` 소유권 검증 추가
- [x] 불일치 시 `IllegalArgumentException` 발생 처리

## 🔗 연관 이슈
closes #16