### PR TITLE
fix: 로그인한 사용자 기준의 '좋아요' 여부 관리

### DIFF
--- a/src/main/java/com/pawpaw/pawpaw/domain/post/controller/PostController.java
+++ b/src/main/java/com/pawpaw/pawpaw/domain/post/controller/PostController.java
@@ -28,16 +28,19 @@ public class PostController {
 
     @GetMapping
     public ResponseEntity<List<PostResponseDto>> getAllPosts(
-            @RequestParam(required = false) String category) {
+            @RequestParam(required = false) String category,
+            @AuthenticationPrincipal User user) {
         if (category != null) {
-            return ResponseEntity.ok(postService.getPostsByCategory(category));
+            return ResponseEntity.ok(postService.getPostsByCategory(category, user));
         }
-        return ResponseEntity.ok(postService.getAllPosts());
+        return ResponseEntity.ok(postService.getAllPosts(user));
     }
 
     @GetMapping("/{postId}")
-    public ResponseEntity<PostResponseDto> getPost(@PathVariable Long postId) {
-        return ResponseEntity.ok(postService.getPost(postId));
+    public ResponseEntity<PostResponseDto> getPost(
+            @PathVariable Long postId,
+            @AuthenticationPrincipal User user) {
+        return ResponseEntity.ok(postService.getPost(postId, user));
     }
 
     @PutMapping("/{postId}")

--- a/src/main/java/com/pawpaw/pawpaw/domain/post/controller/PostLikeController.java
+++ b/src/main/java/com/pawpaw/pawpaw/domain/post/controller/PostLikeController.java
@@ -1,5 +1,6 @@
 package com.pawpaw.pawpaw.domain.post.controller;
 
+import com.pawpaw.pawpaw.domain.post.dto.PostResponseDto;
 import com.pawpaw.pawpaw.domain.post.service.PostLikeService;
 import com.pawpaw.pawpaw.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
@@ -15,10 +16,9 @@ public class PostLikeController {
     private final PostLikeService postLikeService;
 
     @PostMapping("/{postId}/likes")
-    public ResponseEntity<String> toggleLike(
+    public ResponseEntity<PostResponseDto> toggleLike(
             @PathVariable Long postId,
             @AuthenticationPrincipal User user) {
-        boolean liked = postLikeService.toggleLike(postId, user);
-        return ResponseEntity.ok(liked ? "좋아요" : "좋아요 취소");
+        return ResponseEntity.ok(postLikeService.toggleLike(postId, user));
     }
 }

--- a/src/main/java/com/pawpaw/pawpaw/domain/post/dto/PostResponseDto.java
+++ b/src/main/java/com/pawpaw/pawpaw/domain/post/dto/PostResponseDto.java
@@ -15,8 +15,13 @@ public class PostResponseDto {
     private String nickname;
     private LocalDateTime createdAt;
     private int likeCount;
+    private boolean likedByMe;
 
     public PostResponseDto(Post post) {
+        this(post, false);
+    }
+
+    public PostResponseDto(Post post, boolean likedByMe) {
         this.id = post.getId();
         this.category = post.getCategory();
         this.title = post.getTitle();
@@ -24,5 +29,6 @@ public class PostResponseDto {
         this.nickname = post.getUser().getNickname();
         this.createdAt = post.getCreatedAt();
         this.likeCount = post.getLikes().size();
+        this.likedByMe = likedByMe;
     }
 }

--- a/src/main/java/com/pawpaw/pawpaw/domain/post/repository/PostLikeRepository.java
+++ b/src/main/java/com/pawpaw/pawpaw/domain/post/repository/PostLikeRepository.java
@@ -2,11 +2,18 @@ package com.pawpaw.pawpaw.domain.post.repository;
 
 import com.pawpaw.pawpaw.domain.post.entity.PostLike;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.Collection;
 import java.util.Optional;
+import java.util.Set;
 
 public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
     Optional<PostLike> findByPostIdAndUserId(Long postId, Long userId);
     boolean existsByPostIdAndUserId(Long postId, Long userId);
     void deleteByPostIdAndUserId(Long postId, Long userId);
+
+    @Query("SELECT pl.post.id FROM PostLike pl WHERE pl.user.id = :userId AND pl.post.id IN :postIds")
+    Set<Long> findPostIdsByUserIdAndPostIdIn(@Param("userId") Long userId, @Param("postIds") Collection<Long> postIds);
 }

--- a/src/main/java/com/pawpaw/pawpaw/domain/post/repository/PostLikeRepository.java
+++ b/src/main/java/com/pawpaw/pawpaw/domain/post/repository/PostLikeRepository.java
@@ -13,6 +13,7 @@ public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
     Optional<PostLike> findByPostIdAndUserId(Long postId, Long userId);
     boolean existsByPostIdAndUserId(Long postId, Long userId);
     void deleteByPostIdAndUserId(Long postId, Long userId);
+    long countByPostId(Long postId);
 
     @Query("SELECT pl.post.id FROM PostLike pl WHERE pl.user.id = :userId AND pl.post.id IN :postIds")
     Set<Long> findPostIdsByUserIdAndPostIdIn(@Param("userId") Long userId, @Param("postIds") Collection<Long> postIds);

--- a/src/main/java/com/pawpaw/pawpaw/domain/post/service/PostLikeService.java
+++ b/src/main/java/com/pawpaw/pawpaw/domain/post/service/PostLikeService.java
@@ -1,5 +1,6 @@
 package com.pawpaw.pawpaw.domain.post.service;
 
+import com.pawpaw.pawpaw.domain.post.dto.PostResponseDto;
 import com.pawpaw.pawpaw.domain.post.entity.Post;
 import com.pawpaw.pawpaw.domain.post.entity.PostLike;
 import com.pawpaw.pawpaw.domain.post.repository.PostLikeRepository;
@@ -17,19 +18,22 @@ public class PostLikeService {
     private final PostRepository postRepository;
 
     @Transactional
-    public boolean toggleLike(Long postId, User user) {
+    public PostResponseDto toggleLike(Long postId, User user) {
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new IllegalArgumentException("게시글을 찾을 수 없습니다."));
 
+        boolean likedByMe;
         if (postLikeRepository.existsByPostIdAndUserId(postId, user.getId())) {
             postLikeRepository.deleteByPostIdAndUserId(postId, user.getId());
-            return false;
+            likedByMe = false;
         } else {
             postLikeRepository.save(PostLike.builder()
                     .post(post)
                     .user(user)
                     .build());
-            return true;
+            likedByMe = true;
         }
+
+        return new PostResponseDto(post, likedByMe);
     }
 }

--- a/src/main/java/com/pawpaw/pawpaw/domain/post/service/PostService.java
+++ b/src/main/java/com/pawpaw/pawpaw/domain/post/service/PostService.java
@@ -5,13 +5,17 @@ import com.pawpaw.pawpaw.domain.pet.repository.PetRepository;
 import com.pawpaw.pawpaw.domain.post.dto.PostRequestDto;
 import com.pawpaw.pawpaw.domain.post.dto.PostResponseDto;
 import com.pawpaw.pawpaw.domain.post.entity.Post;
+import com.pawpaw.pawpaw.domain.post.repository.PostLikeRepository;
 import com.pawpaw.pawpaw.domain.post.repository.PostRepository;
 import com.pawpaw.pawpaw.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Service
@@ -20,6 +24,7 @@ public class PostService {
 
     private final PostRepository postRepository;
     private final PetRepository petRepository;
+    private final PostLikeRepository postLikeRepository;
 
     @Transactional
     public PostResponseDto createPost(PostRequestDto dto, User user) {
@@ -36,26 +41,24 @@ public class PostService {
     }
 
     @Transactional(readOnly = true)
-    public List<PostResponseDto> getAllPosts() {
-        return postRepository.findAllByOrderByCreatedAtDesc()
-                .stream()
-                .map(PostResponseDto::new)
-                .collect(Collectors.toList());
+    public List<PostResponseDto> getAllPosts(User user) {
+        List<Post> posts = postRepository.findAllByOrderByCreatedAtDesc();
+        return toResponseDtos(posts, user);
     }
 
     @Transactional(readOnly = true)
-    public List<PostResponseDto> getPostsByCategory(String category) {
-        return postRepository.findByCategoryOrderByCreatedAtDesc(category)
-                .stream()
-                .map(PostResponseDto::new)
-                .collect(Collectors.toList());
+    public List<PostResponseDto> getPostsByCategory(String category, User user) {
+        List<Post> posts = postRepository.findByCategoryOrderByCreatedAtDesc(category);
+        return toResponseDtos(posts, user);
     }
 
     @Transactional(readOnly = true)
-    public PostResponseDto getPost(Long postId) {
+    public PostResponseDto getPost(Long postId, User user) {
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new IllegalArgumentException("게시글을 찾을 수 없습니다."));
-        return new PostResponseDto(post);
+        boolean likedByMe = user != null
+                && postLikeRepository.existsByPostIdAndUserId(postId, user.getId());
+        return new PostResponseDto(post, likedByMe);
     }
 
     @Transactional
@@ -81,5 +84,26 @@ public class PostService {
         }
 
         postRepository.delete(post);
+    }
+
+    private List<PostResponseDto> toResponseDtos(List<Post> posts, User user) {
+        if (posts.isEmpty()) {
+            return List.of();
+        }
+        Set<Long> likedPostIds = resolveLikedPostIds(posts, user);
+        return posts.stream()
+                .map(p -> new PostResponseDto(p, likedPostIds.contains(p.getId())))
+                .collect(Collectors.toList());
+    }
+
+    private Set<Long> resolveLikedPostIds(List<Post> posts, User user) {
+        if (user == null) {
+            return Collections.emptySet();
+        }
+        List<Long> postIds = posts.stream().map(Post::getId).filter(Objects::nonNull).toList();
+        if (postIds.isEmpty()) {
+            return Collections.emptySet();
+        }
+        return postLikeRepository.findPostIdsByUserIdAndPostIdIn(user.getId(), postIds);
     }
 }


### PR DESCRIPTION
## 📝 관련 이슈
- https://github.com/pawpaw-project/pawpaw-backend/issues/31

## 💡 변경 사항
### 핵심 수정 내용
- **게시글 DTO 내 좋아요 상태 필드 추가**
  - `PostResponseDto`에 `likedByMe(boolean)` 필드를 추가하여 현재 사용자의 좋아요 여부를 반환하도록 개선했습니다.
  - 기존 생성자와의 하위 호환성을 위해 기본값은 `false`로 처리했습니다.
- **조회 성능 최적화 (N+1 문제 해결)**
  - `PostLikeRepository`에 `findPostIdsByUserIdAndPostIdIn` 메서드를 추가하여, 목록 조회 시 게시글마다 쿼리를 날리지 않고 한 번의 쿼리로 사용자가 좋아요한 ID 집합을 가져오도록 구현했습니다.
- **서비스 및 컨트롤러 로직 고도화**
  - 상세 조회(`getPost`) 및 목록 조회(`getAllPosts`, `getPostsByCategory`) 시 `@AuthenticationPrincipal`을 통해 전달받은 유저 정보를 바탕으로 `likedByMe` 상태를 계산하여 주입합니다.
  - 비로그인 유저 또는 예외 상황에 대비하여 `user == null`일 경우 `false`로 반환하는 방어 코드를 적용했습니다.

### 기술적 의사결정
- **Batch Query 사용:** 목록 조회 시 발생할 수 있는 N+1 문제를 방지하기 위해 `In` 절을 활용한 배치 조회 방식을 채택하여 DB 부하를 최소화했습니다.
- **보안 일관성:** `@AuthenticationPrincipal`을 활용하여 컨트롤러 레이어에서 유저 정보를 주입받음으로써 기존 보안 설정과의 정렬을 맞췄습니다.

## 🧪 테스트 결과
- [x] 게시글 상세 조회 시 `likedByMe` 필드 정상 반영 확인
- [x] 게시글 목록 조회 시 N+1 쿼리 발생 여부 확인 및 정상 데이터 반환 확인
- [ ] 비로그인 유저 접근 시 `likedByMe: false` 응답 확인
