### PR TITLE
bug: likeCount의 실시간 데이터 정합성 문제 해결

### DIFF
--- a/src/main/java/com/pawpaw/pawpaw/domain/post/dto/PostResponseDto.java
+++ b/src/main/java/com/pawpaw/pawpaw/domain/post/dto/PostResponseDto.java
@@ -18,17 +18,21 @@ public class PostResponseDto {
     private boolean likedByMe;
 
     public PostResponseDto(Post post) {
-        this(post, false);
+        this(post, false, post.getLikes().size());
     }
 
     public PostResponseDto(Post post, boolean likedByMe) {
+        this(post, likedByMe, post.getLikes().size());
+    }
+
+    public PostResponseDto(Post post, boolean likedByMe, long likeCount) {
         this.id = post.getId();
         this.category = post.getCategory();
         this.title = post.getTitle();
         this.content = post.getContent();
         this.nickname = post.getUser().getNickname();
         this.createdAt = post.getCreatedAt();
-        this.likeCount = post.getLikes().size();
+        this.likeCount = (int) likeCount;
         this.likedByMe = likedByMe;
     }
 }

--- a/src/main/java/com/pawpaw/pawpaw/domain/post/service/PostLikeService.java
+++ b/src/main/java/com/pawpaw/pawpaw/domain/post/service/PostLikeService.java
@@ -34,6 +34,7 @@ public class PostLikeService {
             likedByMe = true;
         }
 
-        return new PostResponseDto(post, likedByMe);
+        long likeCount = postLikeRepository.countByPostId(postId);
+        return new PostResponseDto(post, likedByMe, likeCount);
     }
 }


### PR DESCRIPTION
## 📝 관련 이슈
- https://github.com/pawpaw-project/pawpaw-backend/issues/34

## 💡 변경 사항
### 핵심 수정 내용
- **PostResponseDto 구조 개선**
  - `likeCount`를 직접 파라미터로 받는 생성자를 추가했습니다.
  - 기존 생성자들은 `post.getLikes().size()`를 기본값으로 사용하되, 새로운 생성자를 위임(this) 호출하도록 리팩토링했습니다.
- **좋아요 토글 로직 정합성 보강**
  - `PostLikeService`에서 토글 작업 완료 후, 컬렉션 사이즈가 아닌 `postLikeRepository.countByPostId(postId)`를 통해 최신 카운트를 조회합니다.
  - 이를 통해 동일 트랜잭션 내의 `save/delete` 결과가 즉시 응답에 반영되도록 보장했습니다.

### 기술적 의사결정
- **왜 Count 쿼리인가?**: `post.getLikes().remove()` 등을 통한 양방향 연관관계 편의 메서드 구현보다, DB에 직접 쿼리를 날리는 방식이 Hibernate의 `auto-flush`를 트리거하여 데이터 무결성을 보장하는 데 가장 안전하다고 판단했습니다.
- **읽기/쓰기 분리 전략**: 데이터 변경이 없는 일반 조회(Read-only) 시에는 추가 쿼리 발생을 방지하기 위해 기존 컬렉션 사이즈를 활용하고, 상태가 변하는 토글(Write) 시점에만 명시적으로 카운트 조회를 수행하여 효율성을 챙겼습니다.

## 🧪 테스트 결과
- [x] 좋아요 클릭 시 `likeCount`가 즉시 1 증가하여 응답되는지 확인
- [x] 좋아요 취소 시 `likeCount`가 즉시 1 감소하여 응답되는지 확인 (기존 버그 해결 확인)
- [x] 목록 조회 및 일반 상세 조회 시 기존 기능 영향도 확인

## 🚩 리뷰 포인트
- `PostResponseDto`에서 `long` 타입을 `(int)`로 캐스팅하고 있습니다. 서비스 규모상 좋아요 수가 `Integer` 범위를 넘지 않을 것으로 판단되나, 확인 부탁드립니다.